### PR TITLE
Fix tree placement relative to terrain chunks

### DIFF
--- a/TreeSystem.gd
+++ b/TreeSystem.gd
@@ -449,13 +449,18 @@ func place_trees_in_chunk(chunk_node: Node3D, chunk_pos: Vector2, biome_type, te
 			continue
 
 		# All checks passed, place a tree
-		var pos = Vector3(world_x, terrain_height, world_z)
-		placed_positions.append(pos)
-		tree_positions[chunk_pos].append(pos)
+                var world_pos = Vector3(world_x, terrain_height, world_z)
+                var local_pos = Vector3(
+                        local_x,
+                        terrain_height - chunk_node.position.y + 0.01,
+                        local_z
+                )
+                placed_positions.append(world_pos)
+                tree_positions[chunk_pos].append(local_pos)
 
-		# Create the tree with a specific type from valid types
-		var selected_tree_type = valid_tree_types[randi() % valid_tree_types.size()]
-		create_tree_at_position(pos, selected_tree_type, chunk_node)
+                # Create the tree with a specific type from valid types
+                var selected_tree_type = valid_tree_types[randi() % valid_tree_types.size()]
+                create_tree_at_position(world_pos, selected_tree_type, chunk_node)
 
 	# Debug output
 	if placed_positions.size() > 0:
@@ -501,36 +506,39 @@ func calculate_terrain_slope(world_x: float, world_z: float) -> float:
 
 
 
-func create_tree_at_position(position: Vector3, tree_type: String, parent_node: Node3D):
-	if not tree_type in tree_prefabs:
-		push_error("Tree type '", tree_type, "' not found!")
-		return
+func create_tree_at_position(world_position: Vector3, tree_type: String, parent_node: Node3D):
+        if not tree_type in tree_prefabs:
+                push_error("Tree type '", tree_type, "' not found!")
+                return
 
-	# Instance the tree prefab
-	var tree_node = tree_prefabs[tree_type].duplicate()
+        # Instance the tree prefab
+        var tree_node = tree_prefabs[tree_type].duplicate()
 
-	# Apply random variations
-	var scale_factor = 1.0 + randf_range(-tree_scale_variation, tree_scale_variation)
-	tree_node.scale = Vector3(scale_factor, scale_factor, scale_factor)
+        # Apply random variations
+        var scale_factor = 1.0 + randf_range(-tree_scale_variation, tree_scale_variation)
+        tree_node.scale = Vector3(scale_factor, scale_factor, scale_factor)
 
-	# Apply random rotation around Y axis
-	tree_node.rotation_degrees.y = randf_range(0, tree_rotation_variation)
+        # Apply random rotation around Y axis
+        tree_node.rotation_degrees.y = randf_range(0, tree_rotation_variation)
 
-	# In TreeSystem.gd - create_tree_at_position function
-	# Replace the current position setting with:
-	var terrain_height = calculate_terrain_height(position.x, position.z)
+        # Determine the precise ground height using world coordinates
+        var terrain_height = calculate_terrain_height(world_position.x, world_position.z)
 
-	# Remove or reduce the terrain_interaction_margin
-	# Set to 0 or a very small value like 0.01
-	position.y = terrain_height + 0.01  # Just enough to avoid z-fighting
-	# Apply the corrected position
-	tree_node.position = position
+        # Convert to the chunk's local space so trees align with the mesh
+        var chunk_origin = parent_node.position
+        var local_position = Vector3(
+                world_position.x - chunk_origin.x,
+                terrain_height - chunk_origin.y + 0.01,
+                world_position.z - chunk_origin.z
+        )
 
-	# Add to parent
-	parent_node.add_child(tree_node)
-	active_trees.append(tree_node)
+        tree_node.position = local_position
 
-	return tree_node
+        # Add to parent
+        parent_node.add_child(tree_node)
+        active_trees.append(tree_node)
+
+        return tree_node
 
 # Update tree chunks when terrain chunks change
 func update_tree_chunks(player_pos: Vector3, view_distance: int, chunk_size: int):


### PR DESCRIPTION
## Summary
- store chunk-local positions for trees while maintaining world coordinates for spacing checks
- convert world placement data into chunk-local transforms when instancing tree prefabs so they align with generated terrain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a3a52624483218c8f54a851c8237d