### PR TITLE
Add pilotable plane to world

### DIFF
--- a/Plane.tscn
+++ b/Plane.tscn
@@ -1,0 +1,82 @@
+[gd_scene load_steps=11 format=3 uid="uid://by66k7wba4bt"]
+
+[ext_resource type="Script" path="res://PlaneController.gd" id="1_x4eim"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_d7l1q"]
+albedo_color = Color(0.82, 0.83, 0.86, 1)
+metallic = 0.1
+roughness = 0.6
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1ut3p"]
+albedo_color = Color(0.74, 0.1, 0.1, 1)
+metallic = 0.0
+roughness = 0.4
+
+[sub_resource type="BoxMesh" id="BoxMesh_0u8rs"]
+size = Vector3(1.4, 1.2, 5.2)
+
+[sub_resource type="BoxMesh" id="BoxMesh_kg4y0"]
+size = Vector3(8, 0.2, 1.6)
+
+[sub_resource type="BoxMesh" id="BoxMesh_lc8pi"]
+size = Vector3(2.4, 0.25, 1.0)
+
+[sub_resource type="BoxMesh" id="BoxMesh_wpsh4"]
+size = Vector3(0.5, 1.4, 0.3)
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_bzujd"]
+bottom_radius = 0.15
+top_radius = 0.15
+height = 0.4
+radial_segments = 12
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ye1ff"]
+size = Vector3(3.4, 1.4, 5.6)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_v8z7f"]
+size = Vector3(3.5, 2.5, 6.5)
+
+[node name="BushPlane" type="CharacterBody3D"]
+script = ExtResource("1_x4eim")
+floor_snap_length = 1.0
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape3D_ye1ff")
+
+[node name="Fuselage" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_0u8rs")
+material_override = SubResource("StandardMaterial3D_d7l1q")
+
+[node name="Wing" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_kg4y0")
+material_override = SubResource("StandardMaterial3D_d7l1q")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, -0.2)
+
+[node name="TailPlane" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_lc8pi")
+material_override = SubResource("StandardMaterial3D_d7l1q")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.65, 2.3)
+
+[node name="TailFin" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_wpsh4")
+material_override = SubResource("StandardMaterial3D_d7l1q")
+transform = Transform3D(1, 0, 0, 0, 0.2, -0.98, 0, 0.98, 0.2, 0, 1.2, 2.1)
+
+[node name="Propeller" type="MeshInstance3D" parent="."]
+mesh = SubResource("CylinderMesh_bzujd")
+material_override = SubResource("StandardMaterial3D_1ut3p")
+transform = Transform3D(0.96, 0, 0.28, 0, 1, 0, -0.28, 0, 0.96, 0, 0.0, -2.9)
+
+[node name="EntryArea" type="Area3D" parent="."]
+monitorable = false
+
+[node name="EntryCollision" type="CollisionShape3D" parent="EntryArea"]
+shape = SubResource("BoxShape3D_v8z7f")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.8, 0.0, -0.5)
+
+[node name="Seat" type="Marker3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.7, -0.5)
+
+[node name="CameraMount" type="Marker3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2, -1.6)
+

--- a/PlaneController.gd
+++ b/PlaneController.gd
@@ -1,0 +1,195 @@
+extends CharacterBody3D
+
+@export var max_speed: float = 85.0
+@export var acceleration: float = 18.0
+@export var throttle_response: float = 1.8
+@export var lift_force: float = 9.0
+@export var gravity_force: float = 14.0
+@export var idle_gravity_force: float = 18.0
+@export var takeoff_speed: float = 35.0
+@export var pitch_speed: float = 1.2
+@export var yaw_speed: float = 0.8
+@export var roll_speed: float = 1.8
+@export var exit_offset: Vector3 = Vector3(-2.2, 0.5, -1.5)
+
+var throttle: float = 0.0
+var current_speed: float = 0.0
+var controlling_player: CharacterBody3D = null
+var nearby_player: CharacterBody3D = null
+var camera_mount: Marker3D
+var seat_marker: Marker3D
+var propeller: Node3D
+var original_camera_parent: Node = null
+var original_camera_transform: Transform3D = Transform3D.IDENTITY
+var stored_player_visibility: bool = true
+var stored_process_input: bool = true
+var stored_process_physics: bool = true
+var disabled_colliders: Array[CollisionShape3D] = []
+
+@onready var entry_area: Area3D = $EntryArea
+
+func _ready():
+        camera_mount = $CameraMount
+        seat_marker = $Seat
+        propeller = $Propeller
+
+        entry_area.body_entered.connect(_on_entry_body_entered)
+        entry_area.body_exited.connect(_on_entry_body_exited)
+
+func _physics_process(delta):
+        _update_propeller(delta)
+
+        if controlling_player:
+                _attach_player_to_seat()
+                _handle_flight_input(delta)
+                _apply_flight_physics(delta)
+
+                if Input.is_action_just_pressed("interact"):
+                        exit_plane()
+        else:
+                _apply_idle_physics(delta)
+
+                if nearby_player and Input.is_action_just_pressed("interact"):
+                        enter_plane(nearby_player)
+
+        move_and_slide()
+
+func _handle_flight_input(delta):
+        var throttle_input = Input.get_action_strength("plane_throttle_up") - Input.get_action_strength("plane_throttle_down")
+        throttle = clamp(throttle + throttle_input * throttle_response * delta, 0.0, 1.0)
+
+        var pitch_input = Input.get_action_strength("plane_pitch_down") - Input.get_action_strength("plane_pitch_up")
+        var yaw_input = Input.get_action_strength("plane_yaw_right") - Input.get_action_strength("plane_yaw_left")
+        var roll_input = Input.get_action_strength("plane_roll_right") - Input.get_action_strength("plane_roll_left")
+
+        rotate_object_local(Vector3.RIGHT, pitch_input * pitch_speed * delta)
+        rotate_y(yaw_input * yaw_speed * delta)
+        rotate_object_local(Vector3.FORWARD, roll_input * roll_speed * delta)
+
+func _apply_flight_physics(delta):
+        current_speed = lerp(current_speed, throttle * max_speed, acceleration * delta)
+
+        var forward = -global_transform.basis.z
+        var up_dir = global_transform.basis.y
+        var lift_ratio = clamp(current_speed / takeoff_speed, 0.0, 1.0)
+
+        var target_velocity = forward * current_speed
+        target_velocity += up_dir * lift_force * lift_ratio
+
+        velocity = velocity.lerp(target_velocity, delta * 2.0)
+        velocity.y -= gravity_force * delta * (1.0 - lift_ratio)
+
+func _apply_idle_physics(delta):
+        throttle = lerp(throttle, 0.0, delta * 1.5)
+        current_speed = lerp(current_speed, 0.0, delta * 1.2)
+
+        var target_velocity = Vector3.ZERO
+        if not is_on_floor():
+                target_velocity.y = velocity.y - idle_gravity_force * delta
+
+        velocity = velocity.lerp(target_velocity, delta * 3.0)
+
+        if is_on_floor():
+                var euler = rotation_degrees
+                euler.x = lerp_angle(euler.x, 0.0, delta * 3.0)
+                euler.z = lerp_angle(euler.z, 0.0, delta * 3.0)
+                rotation_degrees = euler
+
+func _update_propeller(delta):
+        if propeller:
+                var spin_speed = lerp(3.0, 40.0, throttle)
+                propeller.rotate_z(spin_speed * delta)
+
+func _attach_player_to_seat():
+        if not controlling_player:
+                return
+
+        controlling_player.global_transform = seat_marker.global_transform
+        controlling_player.velocity = Vector3.ZERO
+
+func enter_plane(player: CharacterBody3D):
+        if controlling_player:
+                return
+
+        controlling_player = player
+        nearby_player = null
+
+        if controlling_player.has_method("set_control_enabled"):
+                controlling_player.set_control_enabled(false)
+
+        stored_player_visibility = controlling_player.visible
+        controlling_player.visible = false
+
+        stored_process_input = controlling_player.is_processing_input()
+        stored_process_physics = controlling_player.is_physics_processing()
+        controlling_player.set_process_input(false)
+        controlling_player.set_physics_process(false)
+
+        disabled_colliders.clear()
+        for child in controlling_player.get_children():
+                if child is CollisionShape3D:
+                        var collider: CollisionShape3D = child
+                        collider.disabled = true
+                        disabled_colliders.append(collider)
+
+        _attach_player_to_seat()
+
+        var camera = controlling_player.get_node_or_null("Camera3D")
+        if camera:
+                original_camera_parent = camera.get_parent()
+                original_camera_transform = camera.transform
+                camera.get_parent().remove_child(camera)
+                camera_mount.add_child(camera)
+                camera.transform = Transform3D.IDENTITY
+                camera.position = Vector3(0, 0.6, 0)
+                camera.rotation_degrees = Vector3(-5, 0, 0)
+
+        Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
+
+func exit_plane():
+        if not controlling_player:
+                return
+
+        var player = controlling_player
+
+        var camera = camera_mount.get_node_or_null("Camera3D")
+        if camera and original_camera_parent:
+                camera_mount.remove_child(camera)
+                original_camera_parent.add_child(camera)
+                camera.transform = original_camera_transform
+
+        player.visible = stored_player_visibility
+        var exit_position = global_transform.origin + global_transform.basis * exit_offset
+        player.global_position = exit_position
+        player.velocity = Vector3.ZERO
+
+        player.set_process_input(stored_process_input)
+        player.set_physics_process(stored_process_physics)
+
+        if player.has_method("set_control_enabled"):
+                player.set_control_enabled(true)
+
+        for collider in disabled_colliders:
+                if is_instance_valid(collider):
+                        collider.disabled = false
+        disabled_colliders.clear()
+
+        nearby_player = player
+        controlling_player = null
+        original_camera_parent = null
+        original_camera_transform = Transform3D.IDENTITY
+        throttle = 0.0
+        current_speed = 0.0
+        Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
+
+func _on_entry_body_entered(body):
+        if body.name == "Player" and body is CharacterBody3D and body != controlling_player:
+                nearby_player = body
+
+func _on_entry_body_exited(body):
+        if body == nearby_player:
+                nearby_player = null
+
+func lerp_angle(from_angle: float, to_angle: float, weight: float) -> float:
+        var difference = wrapf((to_angle - from_angle), -180.0, 180.0)
+        return from_angle + difference * clamp(weight, 0.0, 1.0)

--- a/PlayerController.gd
+++ b/PlayerController.gd
@@ -16,13 +16,16 @@ var camera_rotation = Vector2()
 
 # State flags
 var is_swimming = false
+var controls_enabled := true
 
 func _ready():
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 
 func _physics_process(delta):
-	# Check if we're in water (set by water system)
-	is_swimming = get_meta("is_swimming", false)
+        if not controls_enabled:
+                return
+        # Check if we're in water (set by water system)
+        is_swimming = get_meta("is_swimming", false)
 	
 	if is_swimming:
 		process_swimming(delta)
@@ -115,9 +118,11 @@ func process_swimming(delta):
 		velocity.y = max(velocity.y, jump_strength / 2)
 
 func _input(event):
-	if event is InputEventMouseMotion:
-		# Fixed: Changed signs to get correct mouse movement
-		camera_rotation = Vector2(-event.relative.x, -event.relative.y)
+        if not controls_enabled:
+                return
+        if event is InputEventMouseMotion:
+                # Fixed: Changed signs to get correct mouse movement
+                camera_rotation = Vector2(-event.relative.x, -event.relative.y)
 
 # Add water splash effect when entering water
 func _on_enter_water():
@@ -157,6 +162,11 @@ func _on_enter_water():
 	splash.explosiveness = 0.8
 	splash.one_shot = true
 	
-	add_child(splash)
-	splash.position.y = -0.5  # Slightly below player origin
-	splash.emitting = true
+        add_child(splash)
+        splash.position.y = -0.5  # Slightly below player origin
+        splash.emitting = true
+
+func set_control_enabled(value: bool):
+        controls_enabled = value
+        if not value:
+                velocity = Vector3.ZERO

--- a/TerrainGenerator.gd
+++ b/TerrainGenerator.gd
@@ -24,6 +24,10 @@ var water_system = null
 @export var start_time: float = 8.0  # Starting hour (24-hour format)
 var astronomical_system = null
 
+# Vehicle settings
+@export var enable_plane: bool = true
+@export var plane_spawn_offset: Vector3 = Vector3(40, 6, -25)
+
 # Noise generation resource
 var noise = FastNoiseLite.new()
 var biome_noise = FastNoiseLite.new()  # For biome selection
@@ -66,11 +70,19 @@ func _ready():
 	# Add player to scene
 	add_player_to_scene()
 	
-	# Generate initial terrain chunks BEFORE tree system
-	var initial_position = Vector3.ZERO
-	if has_node("Player"):
-		initial_position = $Player.global_position
-	update_terrain_chunks(initial_position)
+        # Generate initial terrain chunks BEFORE tree system
+        var initial_position = Vector3.ZERO
+        if has_node("Player"):
+                initial_position = $Player.global_position
+        update_terrain_chunks(initial_position)
+
+        if enable_plane:
+                var plane_timer = Timer.new()
+                plane_timer.one_shot = true
+                plane_timer.wait_time = 0.2
+                plane_timer.autostart = true
+                add_child(plane_timer)
+                plane_timer.timeout.connect(func(): add_plane_to_scene())
 	
 	# Initialize tree system AFTER terrain is generated
 	if enable_trees:
@@ -124,7 +136,52 @@ func initialize_tree_system():
 		var player_pos = Vector3.ZERO
 		if has_node("Player"):
 			player_pos = $Player.global_position
-		tree_system.update_tree_chunks(player_pos, view_distance, chunk_size)
+                tree_system.update_tree_chunks(player_pos, view_distance, chunk_size)
+
+func add_plane_to_scene():
+        if not enable_plane:
+                return
+
+        if has_node("BushPlane"):
+                return
+
+        var plane_packed = load("res://Plane.tscn")
+        if not plane_packed:
+                return
+
+        var plane = plane_packed.instantiate()
+        plane.name = "BushPlane"
+
+        var spawn_origin = Vector3.ZERO
+        if has_node("Player"):
+                spawn_origin = $Player.global_position + plane_spawn_offset
+        else:
+                spawn_origin = plane_spawn_offset
+
+        var spawn_height = get_ground_height(spawn_origin)
+        if spawn_height != null:
+                spawn_origin.y = spawn_height + 1.5
+        else:
+                spawn_origin.y = max(water_level + 2.0, 5.0)
+
+        plane.global_transform = Transform3D(Basis.IDENTITY, spawn_origin)
+        add_child(plane)
+
+func get_ground_height(position: Vector3):
+        if not is_inside_tree():
+                return null
+
+        var space_state = get_world_3d().direct_space_state
+        if not space_state:
+                return null
+
+        var from = position + Vector3.UP * 500.0
+        var to = position - Vector3.UP * 500.0
+        var query = PhysicsRayQueryParameters3D.create(from, to)
+        var result = space_state.intersect_ray(query)
+        if result.is_empty():
+                return null
+        return result.position.y
 
 # Initialize astronomical system
 func initialize_astronomical_system():

--- a/project.godot
+++ b/project.godot
@@ -14,3 +14,42 @@ config/name="wonky_lands"
 run/main_scene="uid://dqgeebl8jivm"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+
+[input]
+
+interact={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":70,"unicode":102,"echo":false,"script":null)]
+}
+plane_throttle_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":90,"physical_keycode":90,"unicode":122,"echo":false,"script":null)]
+}
+plane_throttle_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":88,"physical_keycode":88,"unicode":120,"echo":false,"script":null)]
+}
+plane_pitch_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":83,"physical_keycode":83,"unicode":115,"echo":false,"script":null)]
+}
+plane_pitch_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":87,"physical_keycode":87,"unicode":119,"echo":false,"script":null)]
+}
+plane_roll_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":65,"unicode":97,"echo":false,"script":null)]
+}
+plane_roll_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":68,"unicode":100,"echo":false,"script":null)]
+}
+plane_yaw_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":81,"physical_keycode":81,"unicode":113,"echo":false,"script":null)]
+}
+plane_yaw_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":69,"physical_keycode":69,"unicode":101,"echo":false,"script":null)]
+}


### PR DESCRIPTION
## Summary
- add a bush plane scene and controller that lets the player enter and fly a small aircraft
- spawn the plane near the player on world load and disable the character controller while piloting
- register dedicated flight input mappings for throttle, pitch, roll, yaw, and interaction

## Testing
- not run (Godot project)


------
https://chatgpt.com/codex/tasks/task_e_690a41e8618c8321a5cf76ba681d2d9d